### PR TITLE
git ignores assets folder and ds_store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,9 @@ dist
 
 # config 
 script/src/config.json
+
+# assets
+assets
+
+# macOS
+.DS_store


### PR DESCRIPTION
Would be nice to ignore `assets` folder if it is located under repo.