### PR TITLE
Support webp format

### DIFF
--- a/script/src/create_candy_machine.py
+++ b/script/src/create_candy_machine.py
@@ -16,7 +16,7 @@ def verifyMetadataFiles(_ASSET_FOLDER, _METADATA_FOLDER, _COLLECTION_SIZE):
     is_valid = True
 
     assets = os.listdir(_ASSET_FOLDER)
-    images = [asset.split(".")[0] for asset in assets if asset.endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif'))]
+    images = [asset.split(".")[0] for asset in assets if asset.endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif', '.webp'))]
     metadatas = [metadata for metadata in os.listdir(_METADATA_FOLDER) if metadata.endswith(".json")]
     if len(images) - 1 != _COLLECTION_SIZE or len(metadatas) != _COLLECTION_SIZE:
         print("Metadata files error: Not the same amount of images and/or metadata files as the collectionSize in config.json.")

--- a/script/src/util.py
+++ b/script/src/util.py
@@ -125,7 +125,7 @@ def uploadFolderToIpfs():
     os.chdir(_ASSET_FOLDER)
     failed_file_names = []
     for file in os.listdir():
-        if file.endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif')):
+        if file.endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif', '.webp')):
             file_name = file.split('.')[0]
             file_path = _ASSET_FOLDER + '/' + file
 
@@ -217,7 +217,7 @@ def uploadFolderToArweave():
     os.chdir(_ASSET_FOLDER)
     failed_file_names = []
     for file in os.listdir():
-        if file.endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif')):
+        if file.endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif', '.webp')):
             file_name, format = file.split('.')
             file_path = _ASSET_FOLDER + '/' + file
 


### PR DESCRIPTION
This PR introduces support for a webp format when creating the CM.

webp is supported by all major wallets when rendering as it works in a `<img>` tag natively by supported browsers (everything except IE at this time). 